### PR TITLE
Avoid unnecessary API calls

### DIFF
--- a/lib/tableau_server_client/resources/project.rb
+++ b/lib/tableau_server_client/resources/project.rb
@@ -61,7 +61,7 @@ module TableauServerClient
       end
 
       def workbooks
-        @client.get_collection(Workbook.location(site_path, filter: [])).select {|w|
+        @client.get_collection(Workbook.location(site_path, filter: ["projectName:eq:#{name}"])).select {|w|
           w.project_id == id
         }
       end

--- a/lib/tableau_server_client/resources/user.rb
+++ b/lib/tableau_server_client/resources/user.rb
@@ -29,13 +29,13 @@ module TableauServerClient
 
       def workbooks
         @client.get_collection(Workbook.location(site_path, filter: ["ownerName:eq:#{full_name}"])).select do |w|
-          w.owner.id == id
+          w.owner_id == id
         end
       end
 
       def datasources
         @client.get_collection(Datasource.location(site_path, filter: ["ownerName:eq:#{full_name}"])).select do |d|
-          d.owner.id == id
+          d.owner_id == id
         end
       end
 

--- a/lib/tableau_server_client/resources/view.rb
+++ b/lib/tableau_server_client/resources/view.rb
@@ -11,7 +11,9 @@ module TableauServerClient
 
       def self.from_response(client, path, xml)
         attrs = extract_attributes(xml)
-        attrs['workbook_id'] = xml.xpath("xmlns:workbook")[0]['id']
+        # The workbook-scoped views endpoint (/workbooks/<id>/views) omits the
+        # <workbook> element since it is already implied, so guard against nil.
+        attrs['workbook_id'] = xml.xpath("xmlns:workbook")[0]&.fetch('id', nil)
         new(client, path, attrs)
       end
 

--- a/lib/tableau_server_client/resources/workbook.rb
+++ b/lib/tableau_server_client/resources/workbook.rb
@@ -42,7 +42,7 @@ module TableauServerClient
       end
 
       def views
-        @views ||= @client.get_collection(View.location(site_path)).select {|v| v.workbook_id == id }
+        @views ||= @client.get_collection(View.location(path))
       end
 
       def to_request


### PR DESCRIPTION
- Project#workbooks can be roughly filtered by server side
- The owner's user ID of a workbook is responded as workbook.owner_id; getting it by workbook.owner.id instead needs an additional request
- Workbook#views can be retrieved via workbook-specific views endpoint (/workbooks/<id>/views)

I'm not sure why we can't filter by an ID instead of a name.